### PR TITLE
Slightly increase performance

### DIFF
--- a/timetrials/timetrials_cl.lua
+++ b/timetrials/timetrials_cl.lua
@@ -62,11 +62,10 @@ function preRace()
         -- Loop through all races
         for index, race in pairs(races) do
             if race.isEnabled then
-                -- Draw map marker
-                DrawMarker(1, race.start.x, race.start.y, race.start.z - 1, 0, 0, 0, 0, 0, 0, 3.0001, 3.0001, 1.5001, 255, 165, 0,165, 0, 0, 0,0)
-                
                 -- Check distance from map marker and draw text if close enough
                 if GetDistanceBetweenCoords( race.start.x, race.start.y, race.start.z, GetEntityCoords(player)) < DRAW_TEXT_DISTANCE then
+                    -- Draw map marker
+                    DrawMarker(1, race.start.x, race.start.y, race.start.z - 1, 0, 0, 0, 0, 0, 0, 3.0001, 3.0001, 1.5001, 255, 165, 0,165, 0, 0, 0,0)
                     -- Draw race name
                     Draw3DText(race.start.x, race.start.y, race.start.z-0.600, race.title, RACING_HUD_COLOR, 4, 0.3, 0.3)
                 end


### PR DESCRIPTION
Draw race markers only if the player is near the start point because you don't have to draw a marker if the player can't even see it.

## _Resmon_

- Near race start point: from `~0.14ms` to `~0.10ms`
- Far away from any start point: from `~0.06ms` to `0.04ms`
